### PR TITLE
Example Rpmsg: fixed bit shift for host to interrupt

### DIFF
--- a/BeagleBone/AI/pru/neopixelRpmsg.pru1_1.c
+++ b/BeagleBone/AI/pru/neopixelRpmsg.pru1_1.c
@@ -27,8 +27,8 @@
 volatile register uint32_t __R30;
 volatile register uint32_t __R31;
 
-/* Host-0 Interrupt sets bit 30 in register R31 */
-#define HOST_INT			((uint32_t) 1 << 30)	
+/* Host-1 Interrupt sets bit 31 in register R31 */
+#define HOST_INT			((uint32_t) 1 << 31)
 
 /* The PRU-ICSS system events used for RPMsg are defined in the Linux device tree
  * PRU0 uses system event 16 (To ARM) and 17 (From ARM)


### PR DESCRIPTION
Host interrupt for PRU_1 is 1<<31 and not 1<<30  which is for PRU_0.
(https://git.ti.com/cgit/pru-software-support-package/pru-software-support-package/tree/examples/am572x/PRU_RPMsg_Echo_Interrupt1_1/main.c)